### PR TITLE
addeditadrenalinenode.cpp corrected to read "5000 coins" instead of "10 000 coins"

### DIFF
--- a/src/qt/addeditadrenalinenode.cpp
+++ b/src/qt/addeditadrenalinenode.cpp
@@ -55,7 +55,7 @@ void AddEditAdrenalineNode::on_okButton_clicked()
     else if(ui->txhashLineEdit->text() == "")
     {
         QMessageBox msg;
-        msg.setText("Please enter the transaction hash for the transaction that has 10 000 coins");
+        msg.setText("Please enter the transaction hash for the transaction that has 5000 coins");
         msg.exec();
         return;
     }


### PR DESCRIPTION
[/src/qt/addeditadrenalinenode.cpp#L58](https://github.com/neoscoin/neos-core/blob/6a79397ebd3b49f7806c7cd193732f9199d265b3/src/qt/addeditadrenalinenode.cpp#L58) corrected to read `Please enter the transaction hash for the transaction that has 5000 coins` instead of `Please enter the transaction hash for the transaction that has 10 000 coins`